### PR TITLE
BTA-1545 Update PHP versions for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 sudo: false
 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
+    - 7.1
+    - 7.2
+    - 7.3
 before_install: "composer install"
 script: "vendor/bin/phpunit"


### PR DESCRIPTION
Update PHP versions for travis build to 7.x as older versions are already EOL