### PR TITLE
BTA-1728 Update example with the webhook request validation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,19 @@ To parse webhooks you can use the following snippet:
 
 ```php
 $webhook_content = "{ (...) }"; // The string received through the webhook callback url
+$webhook_headers = [
+    "Authorization-Nonce" => "<authorization-nonce>",
+    "Authorization-Key" => "<authorization-key>",
+    "Authorization-Signature" => "<authorization-signature>"
+];
+$webhook_url = "<url>";
 
 $webhooksApi = new BitPesa\Api\WebhooksApi();
+if (!$webhooksApi->validateWebhookRequest($webhook_url, $webhook_content, $webhook_headers)) {
+    echo "Webhook request validation failed";
+    return false;
+}
+
 $webhook = $webhooksApi->parseResponseString($webhook_content, 'Webhook');
 
 if (strpos($webhook->getEvent(), 'transaction') === 0) {

--- a/examples/client.php
+++ b/examples/client.php
@@ -267,6 +267,11 @@ class Application {
     }
 
     public function webhookParseExample() {
+        $webhook_headers = [
+            "Authorization-Nonce" => "<authorization-nonce>",
+            "Authorization-Key" => "<authorization-key>",
+            "Authorization-Signature" => "<authorization-signature>"
+        ];
         $webhook_content = <<<'JSON'
         {
             "webhook": "85d11cf4-d4d6-46e4-ab7d-91355e80392a",
@@ -451,6 +456,13 @@ class Application {
         }
 JSON;
         $webhooksApi = new WebhooksApi();
+        $webhook_url = "<url>";
+
+        if (!$webhooksApi->validateWebhookRequest($webhook_url, $webhook_content, $webhook_headers)) {
+            echo "Webhook request validation failed";
+            return false;
+        }
+
         $webhook = $webhooksApi->parseResponseString($webhook_content, 'Webhook');
 
         if (strpos($webhook->getEvent(), 'transaction') === 0) {


### PR DESCRIPTION
https://btcafrica.atlassian.net/browse/BTA-1728

Parsing webhooks using the SDK currently assumes the webhook request has already been validated using the Authorization-Signature sent in each request header. 
This updates the webhook parsing example with the request validation call now available in the SDK.